### PR TITLE
Used travis_retry in order to avoid build failures due to network errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,12 @@ compiler: gcc
 
 before_install:
   - buildutils/setup_travis.sh
-  - pip install -U setuptools
-  - pip install cython
-  - pip install pytest
+  - travis_retry pip install -U setuptools
+  - travis_retry pip install cython
+  - travis_retry pip install pytest
 
 install:
-  - pip install --editable .
+  - travis_retry pip install --editable .
 
 # skip testing for pypy + BUILD_CAPNP=false since it's failing in travis for some reason
 script: if [[ $TRAVIS_PYTHON_VERSION != 'pypy' || $BUILD_CAPNP == 'true' ]]; then py.test test; fi


### PR DESCRIPTION
This makes the build more reliable.