### PR TITLE
Force use of virtualized Travic CI infrastructure to allow sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Use older, non-container infrastructure to allow sudo
+sudo: required
+
 language: python
 
 python:


### PR DESCRIPTION
Newly set up projects on Travis CI use their containerized
infrastructure, which doesn't allow setuid programs to run. Adding the
`sudo: required` line opts out of the containerized infrastructure.

The current `setup_travis.sh` uses sudo to call `update-alternatives`
which doesn't have an equivalent yet. Tracking bug for that feature:
    https://github.com/travis-ci/travis-ci/issues/3668