### PR TITLE
Fix KjException init (missing wrapper).

### DIFF
--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -207,6 +207,7 @@ class KjException(Exception):
             self.wrapper = wrapper
             self.message = str(wrapper)
         else:
+            self.wrapper = None
             self.message = message
             self.nature = nature
             self.durability = durability


### PR DESCRIPTION
Some code (e.g. properties) relies on 'wrapper' member being present.