### PR TITLE
Add reraise_kj_exception to the prettyPrint functions.

### DIFF
--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -302,11 +302,11 @@ cdef extern from "<utility>" namespace "std":
     capnp.AsyncIoContext moveAsyncContext"std::move"(capnp.AsyncIoContext)
 
 cdef extern from "<capnp/pretty-print.h>" namespace " ::capnp":
-    StringTree printStructReader" ::capnp::prettyPrint"(C_DynamicStruct.Reader)
-    StringTree printStructBuilder" ::capnp::prettyPrint"(DynamicStruct_Builder)
-    StringTree printRequest" ::capnp::prettyPrint"(Request &)
-    StringTree printListReader" ::capnp::prettyPrint"(C_DynamicList.Reader)
-    StringTree printListBuilder" ::capnp::prettyPrint"(C_DynamicList.Builder)
+    StringTree printStructReader" ::capnp::prettyPrint"(C_DynamicStruct.Reader) except +reraise_kj_exception
+    StringTree printStructBuilder" ::capnp::prettyPrint"(DynamicStruct_Builder) except +reraise_kj_exception
+    StringTree printRequest" ::capnp::prettyPrint"(Request &) except +reraise_kj_exception
+    StringTree printListReader" ::capnp::prettyPrint"(C_DynamicList.Reader) except +reraise_kj_exception
+    StringTree printListBuilder" ::capnp::prettyPrint"(C_DynamicList.Builder) except +reraise_kj_exception
 
 cdef class _NodeReader:
     cdef C_Node.Reader thisptr


### PR DESCRIPTION
I didn't research this enough to know if +reraise_kj_exception is the optimal specifier.  But it matched what I saw elsewhere in the code and fixed the problem in my own informal testing.
