### PR TITLE
make tox and travis setups much more similar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,8 @@ compiler: gcc
 
 before_install:
   - buildutils/setup_travis.sh
-  - travis_retry pip install -U setuptools
-  - travis_retry pip install cython==0.21.2
-  - travis_retry pip install pytest
 
 install:
-  - travis_retry pip install --editable .
+  - travis_retry pip install tox-travis
 
-script: py.test test;
+script: tox

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,9 @@ force_cython = "--force-cython" in sys.argv
 if force_cython:
     sys.argv.remove("--force-cython")
     use_cython = True
+elif os.environ.get('FORCE_CYTHON', None) == '1':
+    use_cython = True
+
 libcapnp_url = None
 try:
     libcapnp_url_index = sys.argv.index("--libcapnp-url")

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,23 @@
 [tox]
-envlist = py27,py32,py33,py34
+envlist = py26,py27,py33,py34,pypy
+
+[tox:travis]
+2.6 = py26
+2.7 = py27
+3.3 = py33
+3.4 = py34
+pypy = pypy
+
 
 [testenv]
 deps=
-    pytest
-    cython
+     --requirement
+     {toxinidir}/requirements.txt
 
 commands =
     py.test
 
-setenv =
-    CFLAGS='-stdlib=libc++'
+setenv  =
+    FORCE_CYTHON = 1
+
+passenv = CC CFLAGS CPPFLAGS CXXFLAGS LDFLAGS


### PR DESCRIPTION
With this change, the dev workflow and the ci workflow are much more similar, and it's more obvious if the env lists get out of sync between tox and travis.

(Not sure how you feel about this, or... frankly, whether it's going to work at all, so I'm submitting this to get a travis run to find out!)