### PR TITLE
Don't create a global EventLoop until someone actually wants one.

### DIFF
--- a/capnp/lib/capnp.pyx
+++ b/capnp/lib/capnp.pyx
@@ -1617,7 +1617,9 @@ cdef class _EventLoop:
     cdef Own[AsyncIoStream] wrapSocketFd(self, int fd):
         return deref(deref(self.thisptr).lowLevelProvider).wrapSocketFd(fd)
 
-cdef _EventLoop C_DEFAULT_EVENT_LOOP = _EventLoop()
+# We don't want to start off with an event loop because creating
+# one will override signal handlers, which the user may not want.
+cdef _EventLoop C_DEFAULT_EVENT_LOOP = None
 
 _C_DEFAULT_EVENT_LOOP_LOCAL = None
 _THREAD_LOCAL_EVENT_LOOPS = []


### PR DESCRIPTION
The simple act of creating an EventLoop will coopt both SIGUSR1 and
SIGPIPE on Linux. This can interfere with the normal execution of
applications which don't need to use the KJ event loop model or
capnproto's RPC implementation.

This is especially hard to work around becausee the event handlers
areee switched in C rather than in Pythhon, so trying to switch them
back innn the Python application after the import isn'tt workable.

This patch prevents the signal handlers from being reassigned until
the EventLoop is actually needed.