### PR TITLE
customize_compiler is recommended by distutils doc

### DIFF
--- a/buildutils/misc.py
+++ b/buildutils/misc.py
@@ -35,7 +35,7 @@ def get_compiler(compiler, **compiler_attrs):
     """get and customize a compiler"""
     if compiler is None or isinstance(compiler, str):
         cc = ccompiler.new_compiler(compiler=compiler)
-        # customize_compiler(cc)
+        customize_compiler(cc)
         if cc.compiler_type == 'mingw32':
             customize_mingw(cc)
     else:


### PR DESCRIPTION
On Unix platforms, environment variables such as CFLAGS, LDFLAGS are not
honored if this is not called.