### PR TITLE
Rework logic to determine whether to use bundled or system libcapnp.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,17 +98,21 @@ class build_libcapnp_ext(build_ext_c):
         build_ext_c.build_extension(self, ext)
 
     def run(self):
-        build_failed = False
-        try:
-            test_build()
-        except CompileError:
-            build_failed = True
+        if force_bundled_libcapnp:
+            need_build = True
+        elif force_system_libcapnp:
+            need_build = False
+        else:
+            # Try to autodetect presence of library. Requires compile/run
+            # step so only works for host (non-cross) compliation
+            try:
+                test_build()
+                need_build = False
+            except CompileError:
+                need_build = True
 
-        if build_failed and force_system_libcapnp:
-            raise RuntimeError("libcapnp C++ library not detected and --force-system-libcapnp was used")
-        if build_failed or force_bundled_libcapnp:
-            if build_failed:
-                info("*WARNING* no libcapnp detected. Will download and build it from source now. If you have C++ Cap'n Proto installed, it may be out of date or is not being detected. Downloading and building libcapnp may take a while.")
+        if need_build:
+            info("*WARNING* no libcapnp detected or rebuild forced. Will download and build it from source now. If you have C++ Cap'n Proto installed, it may be out of date or is not being detected. Downloading and building libcapnp may take a while.")
             bundle_dir = os.path.join(_this_dir, "bundled")
             if not os.path.exists(bundle_dir):
                 os.mkdir(bundle_dir)


### PR DESCRIPTION
The current logic unconditionally tries to build /and run/ a small
executable linked against libcapnp. The 'run' step is ostensibly
to get the current library version number, however this number isn't
actually used anywhere.

More importantly, this breaks cross-compiling completely as in that
mode you can't run an executable that's just been built.

One option would be to fix the build scripts for cross-compiling but
this is relatively complex. This patch implements a simple change
that basically boils down to '--force-system-libcapnp' actually
forcing that, skipping the build and run tests. The assumption is
that if you're cross-compiling then you're most likely to be building
the library yourself anyway and if you're specifying that flag, then
you know what you're doing.